### PR TITLE
Update startup.py

### DIFF
--- a/cola/widgets/startup.py
+++ b/cola/widgets/startup.py
@@ -150,7 +150,7 @@ class StartupDialog(standard.Dialog):
                            self.clone_repo_done, False)
 
     def clone_repo_done(self, task):
-        if task.cmd and task.cmd.ok:
+        if task.cmd and (hasattr(task.cmd, 'ok') or (hasattr(task.cmd, 'status') and task.cmd.status==0)):
             self.repodir = task.destdir
             self.accept()
         else:


### PR DESCRIPTION
Tackle situation whereas AttributeError for pulling missing attribute task.cmd.ok whereas only task.cmd.status (0) is available. (Environment: Ubuntu 16.04, Python 3.6.3 :: Anaconda custom 64-bit)